### PR TITLE
12: fix ttl vs options obj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6 - 05-04-2019
+
+- Fix issue setting TTL on cache requests [#15]
+
 ## v0.1.5 - 28-02-2019
 
 - Update dependencies to resolve cache TTL issue [#12]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ And the peer dependencies (if you do not have them already): `npm i knex graphql
 const Knex = require("knex");
 const { SQLDataSource } = require("datasource-sql");
 
-const MINUTE = 60 * 1000;
+const MINUTE = 60;
 
 const knex = Knex({
   client: "pg",
@@ -89,10 +89,10 @@ SQLCache leverages Apollo's caching strategy to save results between requests an
 
 This method accepts two parameters:
 
-`getCached(knexQuery, ttlInMilliseconds)`
+`getCached(knexQuery, ttlInSeconds)`
 
 - `knexQuery`: <knexObject> A knex object that has not been then'd
-- `ttlInMilliseconds`: <Number> number of milliseconds to keep cached results
+- `ttlInSeconds`: <Number> number of seconds to keep cached results
 
 ### Why not both?
 
@@ -100,10 +100,10 @@ To leverage caching _*and*_ batching for a query, use the method `getCachedAndBa
 
 This method accepts the same two params as `getCached`:
 
-`getBatchedAndCached(knexQuery, ttlInMilliseconds)`
+`getBatchedAndCached(knexQuery, ttlInSeconds)`
 
 - `knexQuery`: <knexObject> A knex object that has not been then'd
-- `ttlInMilliseconds`: <Number> number of milliseconds to keep cached results
+- `ttlInSeconds`: <Number> number of seconds to keep cached results
 
 From the example in the usage section above:
 

--- a/SQLCache.js
+++ b/SQLCache.js
@@ -21,7 +21,7 @@ class SQLCache {
     return this.cache.get(cacheKey).then(entry => {
       if (entry) return Promise.resolve(entry);
       return query.then(rows => {
-        if (rows) this.cache.set(cacheKey, rows, ttl);
+        if (rows) this.cache.set(cacheKey, rows, { ttl });
         return Promise.resolve(rows);
       });
     });
@@ -37,7 +37,7 @@ class SQLCache {
         .load(queryString)
         .then(result => result && result.rows)
         .then(rows => {
-          if (rows) this.cache.set(cacheKey, rows, ttl);
+          if (rows) this.cache.set(cacheKey, rows, { ttl });
           return Promise.resolve(rows);
         });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-sql",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1842,7 +1842,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1863,12 +1864,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1883,17 +1886,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2010,7 +2016,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2022,6 +2029,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2036,6 +2044,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2043,12 +2052,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2067,6 +2078,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2147,7 +2159,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2159,6 +2172,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2244,7 +2258,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2280,6 +2295,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2299,6 +2315,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2342,12 +2359,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-sql",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "SQL DataSource for Apollo GraphQL projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Apollo's setter uses an options object with a TTL prop, therefore, we should match that.

closes #15
closes #12