### PR TITLE
add batching, fix logger for 2 or more instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ To use ( or not use ) the caching feature in v1, simply add `.cache()` to your K
 
 Read more below about getting set up and customizing the cache controls.
 
+## BREAKING CHANGES IN v2.0.0
+
+In v2.0.0 this lib has a new fluid interface that plays nicely with Knex and stays more true to
+the spirit of Apollo DataSources with dynamically batching and caching.
+
+```js
+// batched query
+const query = this.db.select("*").from("fruit").where({ id: 1 }).load();
+
+query.then(data => /* ... */ );
+```
+
+```js
+// cached query for 5ms
+const query = this.db.select("*").from("fruit").where({ id: 1 }).load(5);
+
+query.then(data => /* ... */ );
+```
+
+To use ( or not use ) the batching feature in v2, simply add `.load()` to your Knex query.
+To use ( or not use ) the caching feature in v2, simply add `.load(ttl)` to your Knex query.
+
+Read more below about getting set up and customizing the cache controls.
+
 ## Getting Started
 
 ### Installation
@@ -37,7 +61,7 @@ class MyDatabase extends SQLDataSource {
       .select("*")
       .from("fruit")
       .where({ id: 1 })
-      .cache(MINUTE);
+      .load(MINUTE);
   }
 }
 
@@ -69,17 +93,15 @@ const server = new ApolloServer({
 });
 ```
 
-### Caching ( .cache( ttl ) )
+### Caching ( .load( ttl ) )
 
 If you were to make the same query over the course of multiple requests to your server you could also be making needless requests to your server - especially for expensive queries.
 
-SQLDataSource leverages Apollo's caching strategy to save results between requests and makes that available via `.cache()`.
+SQLDataSource leverages Apollo's caching strategy to save results between requests and makes that
+available via `.load(ttl)`.
 
 This method accepts one OPTIONAL parameter, `ttl` that is the number of seconds to retain the data in the cache.
-
-The default value for cache is `5 seconds`.
-
-configuration, SQLDataSource falls back to an InMemoryLRUCache like the [RESTDataSource].
+If you don't setup `ttl` work only batching.
 
 ## SQLDataSource Properties
 
@@ -89,7 +111,7 @@ SQLDataSource is an ES6 Class that can be extended to make a new SQLDataSource a
 
 Like all DataSources, SQLDataSource has an initialize method that Apollo will call when a new request is routed.
 
-If no cache is provided in your Apollo server
+If no cache is provided in your Apollo server configuration, SQLDataSource falls back to an InMemoryLRUCache like the [RESTDataSource].
 
 ### context
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class SQLDataSource extends DataSource {
   initialize({ context = {}, cache = new InMemoryLRUCache() } = {}) {
     this.context = context;
     this.cache = cache;
+    this.memoizedResults = new Map();
   }
 
   getCacheKey(ttl = "", query) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ class SQLDataSource extends DataSource {
       this.memoizedResults.set(cacheKey, this.getResult(ttl, query, cacheKey));
       return promise;
     }
-    promise = this.cacheQuery(ttl, query);
+    promise = this.cacheQuery(ttl, query, cacheKey);
     this.memoizedResults.set(cacheKey, promise);
     return promise;
   }

--- a/index.js
+++ b/index.js
@@ -6,46 +6,64 @@ const knexTinyLogger = require("knex-tiny-logger").default;
 
 const { DEBUG } = process.env;
 
-let hasLogger = false;
+Knex.QueryBuilder.extend("load", function(ttl) {
+  return this.client.load(ttl, this);
+});
 
 class SQLDataSource extends DataSource {
   constructor(knexConfig) {
     super();
-
+    this.memoizedResults = new Map();
     this.context;
     this.cache;
     this.db = Knex(knexConfig);
-
     const _this = this;
-    Knex.QueryBuilder.extend("cache", function(ttl) {
-      return _this.cacheQuery(ttl, this);
-    });
-  }
-
-  initialize(config) {
-    this.context = config.context;
-    this.cache = config.cache || new InMemoryLRUCache();
-
-    if (DEBUG && !hasLogger) {
-      hasLogger = true; // Prevent duplicate loggers
+    this.db.client.load = (ttl, query) => {
+      return _this.load(ttl, query);
+    };
+    if (DEBUG) {
       knexTinyLogger(this.db); // Add a logging utility for debugging
     }
   }
 
-  cacheQuery(ttl = 5, query) {
-    const cacheKey = crypto
-      .createHash("sha1")
-      .update(query.toString())
-      .digest("base64");
+  initialize({ context = {}, cache = new InMemoryLRUCache() } = {}) {
+    this.context = context;
+    this.cache = cache;
+  }
 
+  getCacheKey(ttl = "", query) {
+    return crypto
+      .createHash("sha1")
+      .update(`${query.toString()}_${ttl}`)
+      .digest("base64");
+  }
+
+  load(ttl, query) {
+    const cacheKey = this.getCacheKey(ttl, query);
+    let promise = this.memoizedResults.get(cacheKey);
+    if (promise) return promise;
+    if (!ttl) {
+      promise = this.getResult(ttl, query, cacheKey);
+      this.memoizedResults.set(cacheKey, this.getResult(ttl, query, cacheKey));
+      return promise;
+    }
+    promise = this.cacheQuery(ttl, query);
+    this.memoizedResults.set(cacheKey, promise);
+    return promise;
+  }
+
+  getResult(ttl, query, cacheKey) {
+    return query.then(rows => {
+      if (!ttl || !rows) return Promise.resolve(rows);
+      this.cache.set(cacheKey, JSON.stringify(rows), { ttl });
+      return Promise.resolve(rows);
+    });
+  }
+
+  cacheQuery(ttl, query, cacheKey) {
     return this.cache.get(cacheKey).then(entry => {
       if (entry) return Promise.resolve(JSON.parse(entry));
-
-      return query.then(rows => {
-        if (rows) this.cache.set(cacheKey, JSON.stringify(rows), { ttl });
-
-        return Promise.resolve(rows);
-      });
+      return this.getResult(ttl, query, cacheKey);
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-sql",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "SQL DataSource for Apollo GraphQL projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- add batching via `load` method
- change logic of caching via add `ttl` to `load` method
- replace `Knex.QueryBuilder.extend` from constructor
- replace knex-tiny-logger to constructor