### PR TITLE
v1.5.0 Add types for `this.db` and `this.context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.0 - 08-09-2021
+
+- Add types for `this.db` and `this.context` ( Thanks @astorije )
+
 ## v1.4.1 - 04-09-2021
 
 - Support GraphQL versions >= v14

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,8 @@ declare module "knex" {
   }
 }
 
-export class SQLDataSource extends DataSource {
+export class SQLDataSource<TContext = any> extends DataSource<TContext> {
+  protected context: TContext;
   protected knex: Knex;
   protected db: Knex;
   constructor(config: Knex.Config | Knex);

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,5 +9,6 @@ declare module "knex" {
 
 export class SQLDataSource extends DataSource {
   protected knex: Knex;
+  protected db: Knex;
   constructor(config: Knex.Config | Knex);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,6 +8,10 @@ class MyTestDataSource extends SQLDataSource {
     expectType<Knex>(this.knex);
   }
 
+  public testDbExists() {
+    expectType<Knex>(this.db);
+  }
+
   public async testCacheFunctionPassesResult() {
     expectType<MyRow[]>(
       await this.knex<MyRow>("mytable")

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,14 +2,22 @@ import { expectError, expectType } from "tsd";
 import Knex from "knex";
 import { SQLDataSource } from "./index";
 
+interface MyTestContext {
+  foo: string;
+}
+
 type MyRow = { id: string; value: number };
-class MyTestDataSource extends SQLDataSource {
+class MyTestDataSource extends SQLDataSource<MyTestContext> {
   public testKnexExists() {
     expectType<Knex>(this.knex);
   }
 
   public testDbExists() {
     expectType<Knex>(this.db);
+  }
+
+  public testContextExists() {
+    expectType<MyTestContext>(this.context);
   }
 
   public async testCacheFunctionPassesResult() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datasource-sql",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datasource-sql",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "apollo-datasource": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-sql",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "SQL DataSource for Apollo GraphQL projects",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.1",
   "description": "SQL DataSource for Apollo GraphQL projects",
   "main": "index.js",
-  "typings": "index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "prettier '**/*.js' && eslint '**/*.js'",
     "lint:fix": "prettier --write '**/*.{js,ts}' && eslint --fix '**/*.js'",


### PR DESCRIPTION
I am currently doing exactly this to store the authenticated user info on the Apollo context: https://www.apollographql.com/docs/apollo-server/security/authentication/#putting-authenticated-user-info-on-the-context

Then, in the datasource, one would want to fetch something based on that user info:

```ts
  findMyFruits() {
    if (!this.context.user) {
      throw new AuthenticationError("you must be logged in");
    }

    return this.knex
      .select()
      .from<Fruit>("fruits")
      .where({ userId: this.context.user.id });
  }
```

By correctly typing the context of the datasource, this avoids some awkward typing such as `(this.context as any).user as User`.

And while I was at it anyway, I figured I'd help with #68 :)