### PR TITLE
Correct bug "ERROR: Can't extend QueryBuilder with existing method ('cache')"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.0 - 04-24-2023
+
+- Resolve issue with .cache declaration (#84) Thanks @daniel-keller
+
 ## v2.0.1 - 03-15-2022
 
 - Update dependencies

--- a/index.js
+++ b/index.js
@@ -22,12 +22,18 @@ class SQLDataSource extends DataSource {
     }
 
     this.knex = this.db;
-
     const _this = this;
+    
+    const cachefn = function(ttl) {
+      return _this.cacheQuery(ttl, this);
+    };
+
     if (!this.db.cache) {
-      Knex.QueryBuilder.extend("cache", function(ttl) {
-        return _this.cacheQuery(ttl, this);
-      });
+      // Extend modifies Knex prototype to include cache method.
+      // Does not retroactively add cache to existing connection.
+      Knex.QueryBuilder.extend("cache", cachefn);
+      // Must be manually added to existing knex connection.
+      this.db.cache = cachefn;
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datasource-sql",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datasource-sql",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "apollo-datasource": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-sql",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "SQL DataSource for Apollo GraphQL projects",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Corrected bug where passing in an existing instance of Knex connection results in failure to extend QueryBuilder with cache method. `ERROR: Can't extend QueryBuilder with existing method ('cache')`

Fixes #81 and I think #83 but I would like @marvin-kolja thoughts on that. See explanation here https://github.com/cvburgess/SQLDataSource/issues/81#issuecomment-1260184741